### PR TITLE
Fix broken BOM link and remove extraneous readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ If you would like to follow the development of Milo, please follow us on Reddit:
 
 ## Getting started
 
-We'd recommend going through the [documentation](./docs/readme.md) - where you can learn about the parts and work needed to get your own machine up and running.
+We'd recommend going through the [documentation](./docs/index.md) - where you can learn about the parts and work needed to get your own machine up and running.

--- a/docs/assembly_manual/chapters/introduction.md
+++ b/docs/assembly_manual/chapters/introduction.md
@@ -17,7 +17,7 @@ Have fun building your very first Milo.
 
 ## Bill of materials
 
-Provided [here](../bom/sourcing_guide.md) is the bill of materials. Whilst we recommend that you try to stick to this list as much as possible, you're an adult (hopefully) and this is your machine. If there is a substitution that you think would lead to a better machine then do that, if there is a feature you don't feel is necessary then don't buy the parts for it.
+Provided [here](../../bom/sourcing_guide.md) is the bill of materials. Whilst we recommend that you try to stick to this list as much as possible, you're an adult (hopefully) and this is your machine. If there is a substitution that you think would lead to a better machine then do that, if there is a feature you don't feel is necessary then don't buy the parts for it.
 
 Furthermore, there are options in the guide that are up to you to decide on, such as drivers, motors and even control boards. Do your research and find what you need to make your build work for you.
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,9 +1,0 @@
-# Millenium-Milo-v1.5 documentation
-
-Here you can find guides on how to source, print and build the machine.
-
-## Guides
-
-- [Sourcing guide](./bom/sourcing_guide.md)
-- [Printing guide](./printing/print_guide.md)
-- [Assembly manual](./assembly_manual/index.md)


### PR DESCRIPTION
@MilleniumMills thanks for merging the previous PR - I just noticed the BOM link was broken and the docs `readme.md` file has been movedto index.md, which is more appropriate if we ever switch to to automated docs generation.